### PR TITLE
Fix dotcloud deployment failure due to unicode fail

### DIFF
--- a/dotcloud-scripts/feed-wp-config.php
+++ b/dotcloud-scripts/feed-wp-config.php
@@ -15,7 +15,7 @@ define("WP_CONFIG_FILE_NAME", dirname(__FILE__) . '/../wp-config.php');
 define("WP_CONFIG_sample_FILE_NAME", dirname(__FILE__) . '/../wp-config-sample.php');
 // the name of the database that will be created for wordpress
 define("DB_NAME", "wordpress"); 
-define("MSG_PREFIX", "[wordpress-on-dotcloud]Â ");
+define("MSG_PREFIX", "[wordpress-on-dotcloud]  ");
 /**********************************
   Reading environment variables
  **********************************/


### PR DESCRIPTION
When pushing to unicode one of the postinstall scripts prints some unicode to stdout. This unicode is causing a failure somewhere inside the dotCloud deployment process. This patch removes that character. I will be reporting this error to dotCloud (my employer) but, for the time being, this patch will allow pushing to dotCloud.
